### PR TITLE
feat: Add professional sector benchmarks and peer comparison tools

### DIFF
--- a/src/app/stocks/[symbol]/page.tsx
+++ b/src/app/stocks/[symbol]/page.tsx
@@ -1,23 +1,28 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
-import { ArrowLeft } from 'lucide-react';
-import type { Quote } from '@/types/market';
-import type { FinancialMetrics } from '@/types/financials';
-import Card from '@/components/ui/Card';
-import StatusBadge from '@/components/ui/StatusBadge';
-import PriceChart from '@/components/stock/PriceChart';
-import ValuationCard from '@/components/stock/ValuationCard';
-import PeerComparison from '@/components/stock/PeerComparison';
-import { formatPercent, formatTradingValueMn, getChangeColor } from '@/lib/format';
+import { useEffect, useState, useMemo } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import type { Quote } from "@/types/market";
+import type { FinancialMetrics } from "@/types/financials";
+import Card from "@/components/ui/Card";
+import StatusBadge from "@/components/ui/StatusBadge";
+import PriceChart from "@/components/stock/PriceChart";
+import ValuationCard from "@/components/stock/ValuationCard";
+import PeerComparison from "@/components/stock/PeerComparison";
+import StandardBenchmarks from "@/components/stock/StandardBenchmarks";
+import {
+  formatPercent,
+  formatTradingValueMn,
+  getChangeColor,
+} from "@/lib/format";
 
 const DATA_FRESHNESS_THRESHOLD = {
   FRESH: 5 * 60 * 1000,
   DELAYED: 60 * 60 * 1000,
 };
 
-type DataStatus = 'fresh' | 'delayed' | 'stale';
+type DataStatus = "fresh" | "delayed" | "stale";
 
 interface ApiError {
   error: string;
@@ -28,53 +33,60 @@ interface ApiError {
 
 function getDataStatus(timestamp: number): DataStatus {
   const age = Date.now() - timestamp;
-  if (age <= DATA_FRESHNESS_THRESHOLD.FRESH) return 'fresh';
-  if (age <= DATA_FRESHNESS_THRESHOLD.DELAYED) return 'delayed';
-  return 'stale';
+  if (age <= DATA_FRESHNESS_THRESHOLD.FRESH) return "fresh";
+  if (age <= DATA_FRESHNESS_THRESHOLD.DELAYED) return "delayed";
+  return "stale";
 }
 
 function formatTimestamp(timestamp: number): string {
-  return new Date(timestamp).toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
+  return new Date(timestamp).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
   });
 }
 
 const METRIC_EXPLANATIONS = {
   revenueGrowth: {
-    title: 'Revenue Growth',
-    explanation: 'Higher revenue growth indicates increasing sales. Compare to industry norms.',
+    title: "Revenue Growth",
+    explanation:
+      "Higher revenue growth indicates increasing sales. Compare to industry norms.",
   },
   epsGrowth: {
-    title: 'EPS Growth',
-    explanation: 'Earnings per share growth shows profitability improvement. Look for consistency.',
+    title: "EPS Growth",
+    explanation:
+      "Earnings per share growth shows profitability improvement. Look for consistency.",
   },
   roe: {
-    title: 'Return on Equity',
-    explanation: 'Higher ROE can indicate efficient capital use. Check leverage levels.',
+    title: "Return on Equity",
+    explanation:
+      "Higher ROE can indicate efficient capital use. Check leverage levels.",
   },
   profitMargin: {
-    title: 'Profit Margin',
-    explanation: 'Shows profit per dollar of revenue. Higher margins suggest competitive advantages.',
+    title: "Profit Margin",
+    explanation:
+      "Shows profit per dollar of revenue. Higher margins suggest competitive advantages.",
   },
   deRatio: {
-    title: 'Debt-to-Equity',
-    explanation: 'Higher leverage amplifies returns and risks. Compare to industry averages.',
+    title: "Debt-to-Equity",
+    explanation:
+      "Higher leverage amplifies returns and risks. Compare to industry averages.",
   },
   peRatio: {
-    title: 'P/E Ratio',
-    explanation: 'Price relative to earnings. Lower P/E may indicate value.',
+    title: "P/E Ratio",
+    explanation: "Price relative to earnings. Lower P/E may indicate value.",
   },
   pbRatio: {
-    title: 'P/B Ratio',
-    explanation: 'Price relative to book value. P/B under 1 may indicate undervaluation.',
+    title: "P/B Ratio",
+    explanation:
+      "Price relative to book value. P/B under 1 may indicate undervaluation.",
   },
   dividendYield: {
-    title: 'Dividend Yield',
-    explanation: 'Annual dividends as percentage of stock price. Verify sustainability.',
+    title: "Dividend Yield",
+    explanation:
+      "Annual dividends as percentage of stock price. Verify sustainability.",
   },
 };
 
@@ -82,39 +94,50 @@ interface MetricCardProps {
   title: string;
   value: string | null;
   explanation: string;
-  status?: 'success' | 'warning' | 'danger' | 'neutral';
+  status?: "success" | "warning" | "danger" | "neutral";
 }
 
-function MetricCard({ title, value, explanation, status = 'neutral' }: MetricCardProps) {
+function MetricCard({
+  title,
+  value,
+  explanation,
+  status = "neutral",
+}: MetricCardProps) {
   const statusColors = {
-    success: 'text-green-600',
-    warning: 'text-yellow-600',
-    danger: 'text-red-600',
-    neutral: 'text-gray-600',
+    success: "text-green-600",
+    warning: "text-yellow-600",
+    danger: "text-red-600",
+    neutral: "text-gray-600",
   };
 
   return (
     <div className="p-3 bg-white rounded-lg border border-gray-100 hover:border-gray-200 transition-colors">
       <div className="flex items-start justify-between mb-2">
         <h4 className="text-xs font-medium text-gray-700">{title}</h4>
-        {status !== 'neutral' && (
+        {status !== "neutral" && (
           <StatusBadge status={status}>
-            {status === 'success' ? 'Good' : status === 'warning' ? 'Check' : 'Caution'}
+            {status === "success"
+              ? "Good"
+              : status === "warning"
+                ? "Check"
+                : "Caution"}
           </StatusBadge>
         )}
       </div>
-      <p className={`text-lg font-bold ${statusColors[status]} mb-1`}>{value ?? '—'}</p>
+      <p className={`text-lg font-bold ${statusColors[status]} mb-1`}>
+        {value ?? "—"}
+      </p>
       <p className="text-xs text-gray-500 leading-snug">{explanation}</p>
     </div>
   );
 }
 
 function getActionableErrorMessage(error: ApiError): string {
-  if (error.details?.includes('Missing NEXT_PUBLIC_STOCK_API_KEY')) {
-    return 'API configuration error: Stock data provider requires an API key.';
+  if (error.details?.includes("Missing NEXT_PUBLIC_STOCK_API_KEY")) {
+    return "API configuration error: Stock data provider requires an API key.";
   }
-  if (error.details?.includes('API key not configured')) {
-    return 'API key not configured. Please set environment variables.';
+  if (error.details?.includes("API key not configured")) {
+    return "API key not configured. Please set environment variables.";
   }
   if (error.provider) {
     return `Stock API error using ${error.provider.toUpperCase()} provider.`;
@@ -125,7 +148,7 @@ function getActionableErrorMessage(error: ApiError): string {
   if (error.status === 500) {
     return `Server error: Unable to fetch stock data. Please try again later.`;
   }
-  return error.details || error.error || 'Failed to load stock data';
+  return error.details || error.error || "Failed to load stock data";
 }
 
 export default function StockDetailPage() {
@@ -136,7 +159,15 @@ export default function StockDetailPage() {
   const [quote, setQuote] = useState<Quote | null>(null);
   const [metrics, setMetrics] = useState<FinancialMetrics | null>(null);
   const [profile, setProfile] = useState<any>(null);
-  const [historicalData, setHistoricalData] = useState<Array<{ date: string; close: number }>>([]);
+  const [historicalData, setHistoricalData] = useState<
+    Array<{
+      date: string;
+      close: number;
+      high: number;
+      low: number;
+      volume: number;
+    }>
+  >([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<ApiError | null>(null);
 
@@ -149,30 +180,39 @@ export default function StockDetailPage() {
         setError(null);
 
         const [quoteRes, fundamentalsRes, historicalRes] = await Promise.all([
-          fetch('/api/stock/' + symbol + '/quote'),
-          fetch('/api/stock/' + symbol + '/fundamentals'),
-          fetch('/api/stock/' + symbol + '/historical?period=2y'),
+          fetch("/api/stock/" + symbol + "/quote"),
+          fetch("/api/stock/" + symbol + "/fundamentals"),
+          fetch("/api/stock/" + symbol + "/historical?period=2y"),
         ]);
 
-        const [quoteData, fundamentalsData, historicalData] = await Promise.all([
-          quoteRes.json(),
-          fundamentalsRes.json(),
-          historicalRes.json(),
-        ]);
+        const [quoteData, fundamentalsData, historicalData] = await Promise.all(
+          [quoteRes.json(), fundamentalsRes.json(), historicalRes.json()],
+        );
 
         if (!quoteRes.ok) {
-          throw new Error(JSON.stringify({ ...quoteData, status: quoteRes.status }));
+          throw new Error(
+            JSON.stringify({ ...quoteData, status: quoteRes.status }),
+          );
         }
         if (!fundamentalsRes.ok) {
-          throw new Error(JSON.stringify({ ...fundamentalsData, status: fundamentalsRes.status }));
+          throw new Error(
+            JSON.stringify({
+              ...fundamentalsData,
+              status: fundamentalsRes.status,
+            }),
+          );
         }
         if (!historicalRes.ok) {
-          throw new Error(JSON.stringify({ ...historicalData, status: historicalRes.status }));
+          throw new Error(
+            JSON.stringify({ ...historicalData, status: historicalRes.status }),
+          );
         }
 
         if (quoteData.error) throw new Error(JSON.stringify(quoteData));
-        if (fundamentalsData.error) throw new Error(JSON.stringify(fundamentalsData));
-        if (historicalData.error) throw new Error(JSON.stringify(historicalData));
+        if (fundamentalsData.error)
+          throw new Error(JSON.stringify(fundamentalsData));
+        if (historicalData.error)
+          throw new Error(JSON.stringify(historicalData));
 
         setQuote(quoteData);
         setMetrics(fundamentalsData.metrics);
@@ -180,8 +220,18 @@ export default function StockDetailPage() {
 
         // Only set historical data if we have valid data points
         const historical = historicalData.data || [];
-        const validHistorical = historical.filter((h: any) => h.date && h.close != null);
-        setHistoricalData(validHistorical.map((h: any) => ({ date: h.date, close: h.close })));
+        const validHistorical = historical.filter(
+          (h: any) => h.date && h.close != null,
+        );
+        setHistoricalData(
+          validHistorical.map((h: any) => ({
+            date: h.date,
+            close: h.close,
+            high: h.high || h.close,
+            low: h.low || h.close,
+            volume: h.volume || 0,
+          })),
+        );
       } catch (err) {
         if (err instanceof Error) {
           try {
@@ -190,7 +240,7 @@ export default function StockDetailPage() {
             setError({ error: err.message });
           }
         } else {
-          setError({ error: 'Failed to load stock data' });
+          setError({ error: "Failed to load stock data" });
         }
       } finally {
         setLoading(false);
@@ -200,6 +250,44 @@ export default function StockDetailPage() {
     fetchData();
   }, [symbol]);
 
+  // Calculate 52-week high/low from historical data (must be before early returns)
+  const week52Data = useMemo(() => {
+    if (historicalData.length === 0 || !quote) return null;
+
+    // Get last 252 trading days (approximately 1 year)
+    const tradingDaysInYear = 252;
+    const last52Weeks = historicalData.slice(-tradingDaysInYear);
+
+    if (last52Weeks.length === 0) return null;
+
+    const week52High = Math.max(...last52Weeks.map((d) => d.high));
+    const week52Low = Math.min(...last52Weeks.map((d) => d.low));
+    const currentPrice = quote.price;
+
+    // Calculate distance percentages
+    const pctFromHigh =
+      currentPrice < week52High
+        ? ((week52High - currentPrice) / week52High) * 100
+        : 0;
+    const pctFromLow =
+      currentPrice > week52Low
+        ? ((currentPrice - week52Low) / week52Low) * 100
+        : 0;
+
+    return {
+      high: week52High,
+      low: week52Low,
+      pctFromHigh,
+      pctFromLow,
+    };
+  }, [historicalData, quote]);
+
+  // Calculate volume ratio (current / average) (must be before early returns)
+  const volumeRatio = useMemo(() => {
+    if (!quote || quote.avgVolume <= 0) return 0;
+    return quote.volume / quote.avgVolume;
+  }, [quote]);
+
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50">
@@ -208,14 +296,14 @@ export default function StockDetailPage() {
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex items-center gap-4">
               <button
-                onClick={() => router.push('/stocks')}
+                onClick={() => router.push("/stocks")}
                 className="p-2 hover:bg-white/10 rounded-lg transition-colors"
                 aria-label="Back to stocks"
               >
                 <ArrowLeft className="w-5 h-5" />
               </button>
               <div>
-                <h1 className="text-xl font-bold">{symbol || 'Loading...'}</h1>
+                <h1 className="text-xl font-bold">{symbol || "Loading..."}</h1>
                 <p className="text-sm text-white/70">Stock Analysis</p>
               </div>
             </div>
@@ -248,7 +336,7 @@ export default function StockDetailPage() {
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex items-center gap-4">
               <button
-                onClick={() => router.push('/stocks')}
+                onClick={() => router.push("/stocks")}
                 className="p-2 hover:bg-white/10 rounded-lg transition-colors"
                 aria-label="Back to stocks"
               >
@@ -267,13 +355,15 @@ export default function StockDetailPage() {
             <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
               <span className="text-3xl">⚠️</span>
             </div>
-            <h2 className="text-xl font-semibold text-gray-900 mb-2">Unable to Load Stock</h2>
+            <h2 className="text-xl font-semibold text-gray-900 mb-2">
+              Unable to Load Stock
+            </h2>
             <p className="text-gray-600 mb-6">{symbol}</p>
             <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
               <p className="text-sm text-red-800">{errorMessage}</p>
             </div>
             <button
-              onClick={() => router.push('/stocks')}
+              onClick={() => router.push("/stocks")}
               className="px-6 py-2.5 bg-[#1e3a5f] text-white font-medium rounded-lg hover:bg-[#2a4a6f] transition-colors"
             >
               Back to Stock Search
@@ -292,7 +382,7 @@ export default function StockDetailPage() {
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex items-center gap-4">
               <button
-                onClick={() => router.push('/stocks')}
+                onClick={() => router.push("/stocks")}
                 className="p-2 hover:bg-white/10 rounded-lg transition-colors"
                 aria-label="Back to stocks"
               >
@@ -311,12 +401,15 @@ export default function StockDetailPage() {
             <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
               <span className="text-3xl">📊</span>
             </div>
-            <h2 className="text-xl font-semibold text-gray-900 mb-2">Stock Not Found</h2>
+            <h2 className="text-xl font-semibold text-gray-900 mb-2">
+              Stock Not Found
+            </h2>
             <p className="text-gray-600 mb-6">
-              No data available for symbol: <span className="font-mono font-semibold">{symbol}</span>
+              No data available for symbol:{" "}
+              <span className="font-mono font-semibold">{symbol}</span>
             </p>
             <button
-              onClick={() => router.push('/stocks')}
+              onClick={() => router.push("/stocks")}
               className="px-6 py-2.5 bg-[#1e3a5f] text-white font-medium rounded-lg hover:bg-[#2a4a6f] transition-colors"
             >
               Back to Stock Search
@@ -329,9 +422,17 @@ export default function StockDetailPage() {
 
   const dataStatus = getDataStatus(quote.timestamp);
   const statusConfig = {
-    fresh: { label: 'Live', status: 'success' as const, color: 'text-green-600' },
-    delayed: { label: 'Delayed', status: 'warning' as const, color: 'text-yellow-600' },
-    stale: { label: 'Stale', status: 'danger' as const, color: 'text-red-600' },
+    fresh: {
+      label: "Live",
+      status: "success" as const,
+      color: "text-green-600",
+    },
+    delayed: {
+      label: "Delayed",
+      status: "warning" as const,
+      color: "text-yellow-600",
+    },
+    stale: { label: "Stale", status: "danger" as const, color: "text-red-600" },
   };
 
   return (
@@ -342,7 +443,7 @@ export default function StockDetailPage() {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
               <button
-                onClick={() => router.push('/stocks')}
+                onClick={() => router.push("/stocks")}
                 className="p-2 hover:bg-white/10 rounded-lg transition-colors"
                 aria-label="Back to stock search"
               >
@@ -351,7 +452,9 @@ export default function StockDetailPage() {
               <div>
                 <h1 className="text-2xl sm:text-3xl font-bold">{symbol}</h1>
                 {profile?.name && (
-                  <p className="text-sm sm:text-base text-white/80">{profile.name}</p>
+                  <p className="text-sm sm:text-base text-white/80">
+                    {profile.name}
+                  </p>
                 )}
               </div>
             </div>
@@ -378,8 +481,12 @@ export default function StockDetailPage() {
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
               {/* Symbol & Name */}
               <div className="p-4 sm:p-5">
-                <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">Symbol</p>
-                <p className="text-xl sm:text-2xl font-bold text-[#1e3a5f]">{symbol}</p>
+                <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">
+                  Symbol
+                </p>
+                <p className="text-xl sm:text-2xl font-bold text-[#1e3a5f]">
+                  {symbol}
+                </p>
                 {profile?.sector && (
                   <p className="text-xs text-gray-500 mt-1">{profile.sector}</p>
                 )}
@@ -387,44 +494,102 @@ export default function StockDetailPage() {
 
               {/* Current Price */}
               <div className="p-4 sm:p-5">
-                <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">Price</p>
+                <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">
+                  Price
+                </p>
                 <div className="flex items-baseline gap-2">
                   <p className="text-2xl sm:text-3xl font-bold text-gray-900">
                     ${quote.price.toFixed(2)}
                   </p>
-                  <div className={`text-lg font-semibold ${getChangeColor(quote.changePercent)}`}>
-                    {quote.change >= 0 ? '+' : ''}{quote.change.toFixed(2)} ({formatPercent(quote.changePercent)})
+                  <div
+                    className={`text-lg font-semibold ${getChangeColor(quote.changePercent)}`}
+                  >
+                    {quote.change >= 0 ? "+" : ""}
+                    {quote.change.toFixed(2)} (
+                    {formatPercent(quote.changePercent)})
                   </div>
                 </div>
               </div>
 
-              {/* Day Range */}
+              {/* Day Range & 52W Range */}
               <div className="p-4 sm:p-5">
-                <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">Day Range</p>
-                <div className="flex items-center gap-3 text-sm">
+                <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">
+                  Day Range
+                </p>
+                <div className="flex items-center gap-3 text-sm mb-2">
                   <div>
                     <span className="text-gray-500">High:</span>
-                    <span className="ml-1 font-medium">{quote.high.toFixed(2)}</span>
+                    <span className="ml-1 font-medium">
+                      {quote.high.toFixed(2)}
+                    </span>
                   </div>
                   <div className="w-px h-4 bg-gray-200"></div>
                   <div>
                     <span className="text-gray-500">Low:</span>
-                    <span className="ml-1 font-medium">{quote.low.toFixed(2)}</span>
+                    <span className="ml-1 font-medium">
+                      {quote.low.toFixed(2)}
+                    </span>
                   </div>
                 </div>
+                {week52Data && (
+                  <>
+                    <div className="border-t border-gray-100 my-2"></div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">
+                      52W Range
+                    </p>
+                    <div className="flex items-center gap-3 text-sm">
+                      <div>
+                        <span className="text-gray-500">High:</span>
+                        <span className="ml-1 font-medium text-red-600">
+                          {week52Data.high.toFixed(2)}
+                        </span>
+                        <span className="text-xs text-gray-400 ml-1">
+                          (-{week52Data.pctFromHigh.toFixed(1)}%)
+                        </span>
+                      </div>
+                      <div className="w-px h-4 bg-gray-200"></div>
+                      <div>
+                        <span className="text-gray-500">Low:</span>
+                        <span className="ml-1 font-medium text-green-600">
+                          {week52Data.low.toFixed(2)}
+                        </span>
+                        <span className="text-xs text-gray-400 ml-1">
+                          (+{week52Data.pctFromLow.toFixed(1)}%)
+                        </span>
+                      </div>
+                    </div>
+                  </>
+                )}
               </div>
 
               {/* Market Cap & Volume */}
               <div className="p-4 sm:p-5">
-                <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">Market Data</p>
+                <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">
+                  Market Data
+                </p>
                 <div className="space-y-1">
                   <div className="flex justify-between text-sm">
                     <span className="text-gray-500">Market Cap:</span>
-                    <span className="font-medium ml-2">{formatTradingValueMn(quote.marketCap)}</span>
+                    <span className="font-medium ml-2">
+                      {formatTradingValueMn(quote.marketCap)}
+                    </span>
                   </div>
-                  <div className="flex justify-between text-sm">
+                  <div className="flex justify-between text-sm items-center">
                     <span className="text-gray-500">Volume:</span>
-                    <span className="font-medium ml-2">{formatTradingValueMn(quote.volume)}</span>
+                    <span className="font-medium ml-2">
+                      {formatTradingValueMn(quote.volume)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between text-sm items-center">
+                    <span className="text-gray-500">Vol/Avg:</span>
+                    <span
+                      className={`font-medium ml-2 ${volumeRatio > 1.5 ? "text-green-600" : volumeRatio < 0.5 ? "text-red-600" : "text-gray-700"}`}
+                    >
+                      {volumeRatio > 0 ? volumeRatio.toFixed(2) + "x" : "N/A"}
+                      {volumeRatio > 1.5 && (
+                        <span className="ml-1 text-xs">🔥</span>
+                      )}
+                    </span>
                   </div>
                 </div>
               </div>
@@ -442,10 +607,7 @@ export default function StockDetailPage() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
           {/* Price Chart with Moving Averages */}
           <div className="lg:col-span-2">
-            <PriceChart
-              historicalData={historicalData}
-              symbol={symbol}
-            />
+            <PriceChart historicalData={historicalData} symbol={symbol} />
           </div>
 
           {/* Quick Stats */}
@@ -455,19 +617,27 @@ export default function StockDetailPage() {
               <div className="space-y-3">
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-gray-600">Valuation Analysis</span>
-                  <span className="text-xs bg-green-100 px-2 py-1 rounded text-green-700">✓ Active</span>
+                  <span className="text-xs bg-green-100 px-2 py-1 rounded text-green-700">
+                    ✓ Active
+                  </span>
                 </div>
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-gray-600">Peer Comparison</span>
-                  <span className="text-xs bg-green-100 px-2 py-1 rounded text-green-700">✓ Active</span>
+                  <span className="text-xs bg-green-100 px-2 py-1 rounded text-green-700">
+                    ✓ Active
+                  </span>
                 </div>
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-gray-600">CAN SLIM</span>
-                  <span className="text-xs bg-gray-100 px-2 py-1 rounded text-gray-500">Phase 2</span>
+                  <span className="text-xs bg-gray-100 px-2 py-1 rounded text-gray-500">
+                    Phase 2
+                  </span>
                 </div>
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-gray-600">SPEA</span>
-                  <span className="text-xs bg-gray-100 px-2 py-1 rounded text-gray-500">Phase 2</span>
+                  <span className="text-xs bg-gray-100 px-2 py-1 rounded text-gray-500">
+                    Phase 2
+                  </span>
                 </div>
               </div>
             </Card>
@@ -499,72 +669,140 @@ export default function StockDetailPage() {
         </div>
 
         {/* Financial Metrics */}
-        <Card title="Financial Metrics" subtitle="Key fundamental indicators">
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            <MetricCard
-              title={METRIC_EXPLANATIONS.revenueGrowth.title}
-              value={metrics?.revenueGrowth != null ? formatPercent(metrics.revenueGrowth) : null}
-              explanation={METRIC_EXPLANATIONS.revenueGrowth.explanation}
-              status={metrics?.revenueGrowth != null && metrics.revenueGrowth > 0 ? 'success' : metrics?.revenueGrowth != null && metrics.revenueGrowth < 0 ? 'danger' : 'neutral'}
-            />
-            <MetricCard
-              title={METRIC_EXPLANATIONS.epsGrowth.title}
-              value={metrics?.epsGrowth != null ? formatPercent(metrics.epsGrowth) : null}
-              explanation={METRIC_EXPLANATIONS.epsGrowth.explanation}
-              status={metrics?.epsGrowth != null && metrics.epsGrowth > 0 ? 'success' : metrics?.epsGrowth != null && metrics.epsGrowth < 0 ? 'danger' : 'neutral'}
-            />
-            <MetricCard
-              title={METRIC_EXPLANATIONS.roe.title}
-              value={metrics?.roe != null ? metrics.roe.toFixed(2) : null}
-              explanation={METRIC_EXPLANATIONS.roe.explanation}
-              status={metrics?.roe != null && metrics.roe > 15 ? 'success' : metrics?.roe != null && metrics.roe < 5 ? 'danger' : 'neutral'}
-            />
-            <MetricCard
-              title={METRIC_EXPLANATIONS.profitMargin.title}
-              value={metrics?.profitMargin != null ? formatPercent(metrics.profitMargin * 100) : null}
-              explanation={METRIC_EXPLANATIONS.profitMargin.explanation}
-              status={metrics?.profitMargin != null && metrics.profitMargin > 0.1 ? 'success' : metrics?.profitMargin != null && metrics.profitMargin < 0 ? 'danger' : 'neutral'}
-            />
-            <MetricCard
-              title={METRIC_EXPLANATIONS.deRatio.title}
-              value={metrics?.deRatio != null ? metrics.deRatio.toFixed(2) : null}
-              explanation={METRIC_EXPLANATIONS.deRatio.explanation}
-              status={metrics?.deRatio != null && metrics.deRatio > 2 ? 'warning' : 'neutral'}
-            />
-            <MetricCard
-              title={METRIC_EXPLANATIONS.peRatio.title}
-              value={metrics?.peRatio != null && metrics.peRatio > 0 ? metrics.peRatio.toFixed(2) : null}
-              explanation={METRIC_EXPLANATIONS.peRatio.explanation}
-              status='neutral'
-            />
-            <MetricCard
-              title={METRIC_EXPLANATIONS.pbRatio.title}
-              value={metrics?.pbRatio != null && metrics.pbRatio > 0 ? metrics.pbRatio.toFixed(2) : null}
-              explanation={METRIC_EXPLANATIONS.pbRatio.explanation}
-              status='neutral'
-            />
-            <MetricCard
-              title={METRIC_EXPLANATIONS.dividendYield.title}
-              value={metrics?.dividendYield != null && metrics.dividendYield > 0 ? formatPercent(metrics.dividendYield * 100) : null}
-              explanation={METRIC_EXPLANATIONS.dividendYield.explanation}
-              status='neutral'
-            />
-          </div>
-        </Card>
+        <div className="mb-6">
+          <Card title="Financial Metrics" subtitle="Key fundamental indicators">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+              <MetricCard
+                title={METRIC_EXPLANATIONS.revenueGrowth.title}
+                value={
+                  metrics?.revenueGrowth != null
+                    ? formatPercent(metrics.revenueGrowth)
+                    : null
+                }
+                explanation={METRIC_EXPLANATIONS.revenueGrowth.explanation}
+                status={
+                  metrics?.revenueGrowth != null && metrics.revenueGrowth > 0
+                    ? "success"
+                    : metrics?.revenueGrowth != null &&
+                        metrics.revenueGrowth < 0
+                      ? "danger"
+                      : "neutral"
+                }
+              />
+              <MetricCard
+                title={METRIC_EXPLANATIONS.epsGrowth.title}
+                value={
+                  metrics?.epsGrowth != null
+                    ? formatPercent(metrics.epsGrowth)
+                    : null
+                }
+                explanation={METRIC_EXPLANATIONS.epsGrowth.explanation}
+                status={
+                  metrics?.epsGrowth != null && metrics.epsGrowth > 0
+                    ? "success"
+                    : metrics?.epsGrowth != null && metrics.epsGrowth < 0
+                      ? "danger"
+                      : "neutral"
+                }
+              />
+              <MetricCard
+                title={METRIC_EXPLANATIONS.roe.title}
+                value={metrics?.roe != null ? metrics.roe.toFixed(2) : null}
+                explanation={METRIC_EXPLANATIONS.roe.explanation}
+                status={
+                  metrics?.roe != null && metrics.roe > 15
+                    ? "success"
+                    : metrics?.roe != null && metrics.roe < 5
+                      ? "danger"
+                      : "neutral"
+                }
+              />
+              <MetricCard
+                title={METRIC_EXPLANATIONS.profitMargin.title}
+                value={
+                  metrics?.profitMargin != null
+                    ? formatPercent(metrics.profitMargin * 100)
+                    : null
+                }
+                explanation={METRIC_EXPLANATIONS.profitMargin.explanation}
+                status={
+                  metrics?.profitMargin != null && metrics.profitMargin > 0.1
+                    ? "success"
+                    : metrics?.profitMargin != null && metrics.profitMargin < 0
+                      ? "danger"
+                      : "neutral"
+                }
+              />
+              <MetricCard
+                title={METRIC_EXPLANATIONS.deRatio.title}
+                value={
+                  metrics?.deRatio != null ? metrics.deRatio.toFixed(2) : null
+                }
+                explanation={METRIC_EXPLANATIONS.deRatio.explanation}
+                status={
+                  metrics?.deRatio != null && metrics.deRatio > 2
+                    ? "warning"
+                    : "neutral"
+                }
+              />
+              <MetricCard
+                title={METRIC_EXPLANATIONS.peRatio.title}
+                value={
+                  metrics?.peRatio != null && metrics.peRatio > 0
+                    ? metrics.peRatio.toFixed(2)
+                    : null
+                }
+                explanation={METRIC_EXPLANATIONS.peRatio.explanation}
+                status="neutral"
+              />
+              <MetricCard
+                title={METRIC_EXPLANATIONS.pbRatio.title}
+                value={
+                  metrics?.pbRatio != null && metrics.pbRatio > 0
+                    ? metrics.pbRatio.toFixed(2)
+                    : null
+                }
+                explanation={METRIC_EXPLANATIONS.pbRatio.explanation}
+                status="neutral"
+              />
+              <MetricCard
+                title={METRIC_EXPLANATIONS.dividendYield.title}
+                value={
+                  metrics?.dividendYield != null && metrics.dividendYield > 0
+                    ? formatPercent(metrics.dividendYield * 100)
+                    : null
+                }
+                explanation={METRIC_EXPLANATIONS.dividendYield.explanation}
+                status="neutral"
+              />
+            </div>
+          </Card>
+        </div>
 
         {/* Valuation Analysis */}
-        <ValuationCard
-          symbol={symbol}
-          currentPrice={quote.price}
-          metrics={metrics}
-        />
+        <div className="mb-6">
+          <ValuationCard
+            symbol={symbol}
+            currentPrice={quote.price}
+            metrics={metrics}
+          />
+        </div>
+
+        {/* Standard Benchmarks */}
+        <div className="mb-6">
+          <Card title="Standard Benchmarks" subtitle="Compare with SET Index and Sector standards">
+            <StandardBenchmarks symbol={symbol} metrics={metrics} />
+          </Card>
+        </div>
 
         {/* Peer Comparison */}
-        <PeerComparison
-          symbol={symbol}
-          sector={profile?.sector}
-          currentMetrics={metrics}
-        />
+        <div className="mb-6">
+          <PeerComparison
+            symbol={symbol}
+            sector={profile?.sector}
+            currentMetrics={metrics}
+          />
+        </div>
 
         {/* Company Profile (if available) */}
         {profile?.description && (
@@ -601,9 +839,13 @@ export default function StockDetailPage() {
                 Data Source Information
               </p>
               <p className="text-xs text-blue-800">
-                <strong>US Stocks:</strong> Full data coverage via Yahoo Finance<br />
-                <strong>Thai Stocks (.BK):</strong> Limited fundamental data available on Yahoo Finance<br />
-                <strong>Historical Charts:</strong> Only displayed when sufficient data points are available
+                <strong>US Stocks:</strong> Full data coverage via Yahoo Finance
+                <br />
+                <strong>Thai Stocks (.BK):</strong> Limited fundamental data
+                available on Yahoo Finance
+                <br />
+                <strong>Historical Charts:</strong> Only displayed when
+                sufficient data points are available
               </p>
             </div>
           </div>

--- a/src/components/settrade/TopRankingsCard.tsx
+++ b/src/components/settrade/TopRankingsCard.tsx
@@ -36,7 +36,7 @@ export default function TopRankingsCard({ topByValue, topByVolume }: TopRankings
         <div className="space-y-1">
           {topByValue.slice(0, 8).map((stock, i) => (
             <div
-              key={stock.symbol}
+              key={`value-${stock.symbol}`}
               className="flex items-center justify-between py-1.5 px-2 bg-white border border-gray-100 rounded hover:border-gray-200 transition-colors cursor-pointer group"
               onClick={() => window.location.href = `/stocks/${stock.symbol}.BK`}
             >
@@ -73,7 +73,7 @@ export default function TopRankingsCard({ topByValue, topByVolume }: TopRankings
         <div className="space-y-1">
           {topByVolume.slice(0, 8).map((stock, i) => (
             <div
-              key={stock.symbol}
+              key={`volume-${stock.symbol}`}
               className="flex items-center justify-between py-1.5 px-2 bg-white border border-gray-100 rounded hover:border-gray-200 transition-colors cursor-pointer group"
               onClick={() => window.location.href = `/stocks/${stock.symbol}.BK`}
             >

--- a/src/components/stock/StandardBenchmarks.tsx
+++ b/src/components/stock/StandardBenchmarks.tsx
@@ -1,0 +1,313 @@
+/**
+ * Professional Standard Benchmarks Component
+ * Displays Stock vs SET Index vs Sector comparison
+ * Professional investor-friendly layout
+ */
+
+'use client';
+
+import { formatPercent } from '@/lib/format';
+import { SET_INDEX_BENCHMARK, getSectorBenchmark, getSectorName, getSectorForSymbol, SECTOR_PEER_GROUPS } from '@/lib/sectorStandards';
+import type { FinancialMetrics } from '@/types/financials';
+
+interface StandardBenchmarksProps {
+  symbol: string;
+  metrics: FinancialMetrics | null;
+}
+
+// Status badge for showing comparison result
+function StatusBadge({ value, benchmark, lowerBetter }: { value: number | null; benchmark: number; lowerBetter: boolean }) {
+  if (value === null) return null;
+
+  const diff = ((value - benchmark) / benchmark) * 100;
+  const isBetter = lowerBetter ? diff < 0 : diff > 0;
+  const isNeutral = Math.abs(diff) < 5; // Within 5% is neutral
+
+  if (isNeutral) {
+    return (
+      <span className="inline-flex items-center px-1.5 sm:px-2 py-0.5 rounded-full text-[10px] sm:text-xs font-medium bg-gray-100 text-gray-600">
+        ≈ In line
+      </span>
+    );
+  }
+
+  if (isBetter) {
+    return (
+      <span className="inline-flex items-center px-1.5 sm:px-2 py-0.5 rounded-full text-[10px] sm:text-xs font-medium bg-green-100 text-green-700">
+        ✓ Better ({diff > 0 ? '+' : ''}{diff.toFixed(0)}%)
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center px-1.5 sm:px-2 py-0.5 rounded-full text-[10px] sm:text-xs font-medium bg-red-100 text-red-700">
+      ✗ Worse ({diff > 0 ? '+' : ''}{diff.toFixed(0)}%)
+    </span>
+  );
+}
+
+// Comparison row component
+function ComparisonRow({
+  label,
+  stockValue,
+  setValue,
+  sectorValue,
+  format,
+  lowerBetter,
+  unit = '',
+}: {
+  label: string;
+  stockValue: number | null;
+  setValue: number;
+  sectorValue: number;
+  format: (v: number) => string;
+  lowerBetter: boolean;
+  unit?: string;
+}) {
+  const getVsSetColor = (value: number | null, benchmark: number) => {
+    if (value === null) return 'text-gray-400';
+    const diff = ((value - benchmark) / benchmark) * 100;
+    if (Math.abs(diff) < 5) return 'text-gray-600';
+    return lowerBetter ? (value < benchmark ? 'text-green-600' : 'text-red-600')
+                     : (value > benchmark ? 'text-green-600' : 'text-red-600');
+  };
+
+  return (
+    <div className="grid grid-cols-4 gap-2 sm:gap-3 py-3 border-b border-gray-100 last:border-0 items-center min-w-[500px] sm:min-w-0">
+      <div className="text-xs sm:text-sm font-medium text-gray-700">{label}</div>
+
+      {/* Stock */}
+      <div className="text-right">
+        <div className={`text-sm sm:text-base font-bold ${getVsSetColor(stockValue, setValue)}`}>
+          {stockValue !== null ? format(stockValue) : 'N/A'}
+        </div>
+        <div className="text-[10px] sm:text-xs text-gray-400">vs {setValue.toFixed(1)}{unit}</div>
+      </div>
+
+      {/* SET Index */}
+      <div className="text-center">
+        <div className="text-xs sm:text-sm font-semibold text-blue-700">{format(setValue)}</div>
+        <div className="text-[10px] sm:text-xs text-gray-500">SET Index</div>
+      </div>
+
+      {/* Sector */}
+      <div className="text-right">
+        <div className="text-xs sm:text-sm font-semibold text-purple-700">{format(sectorValue)}</div>
+        <div className="text-[10px] sm:text-xs text-gray-500">Sector</div>
+      </div>
+    </div>
+  );
+}
+
+export default function StandardBenchmarks({ symbol, metrics }: StandardBenchmarksProps) {
+  const sectorKey = getSectorForSymbol(symbol);
+  const sectorBenchmark = sectorKey ? SECTOR_PEER_GROUPS[sectorKey].benchmark : null;
+  const sectorName = sectorKey ? SECTOR_PEER_GROUPS[sectorKey].name : null;
+
+  if (!sectorBenchmark) {
+    return (
+      <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center">
+        <span className="text-4xl mb-3">📊</span>
+        <p className="text-sm font-semibold text-gray-700 mb-1">Sector benchmarks not available</p>
+        <p className="text-xs text-gray-500">Standard comparisons are available for Thai SET stocks</p>
+      </div>
+    );
+  }
+
+  // Calculate overall scores
+  const getScore = () => {
+    if (!metrics) return null;
+
+    let better = 0;
+    let worse = 0;
+    let total = 0;
+
+    if (metrics.peRatio !== null && metrics.peRatio > 0) {
+      total++;
+      if (metrics.peRatio < SET_INDEX_BENCHMARK.peRatio) better++; else worse++;
+    }
+    if (metrics.pbRatio !== null && metrics.pbRatio > 0) {
+      total++;
+      if (metrics.pbRatio < SET_INDEX_BENCHMARK.pbRatio) better++; else worse++;
+    }
+    if (metrics.dividendYield !== null && metrics.dividendYield > 0) {
+      total++;
+      if (metrics.dividendYield * 100 > SET_INDEX_BENCHMARK.dividendYield) better++; else worse++;
+    }
+
+    return { better, worse, total };
+  };
+
+  const score = getScore();
+
+  return (
+    <div className="space-y-4 sm:space-y-6">
+      {/* Header with overall assessment */}
+      <div className="bg-gradient-to-r from-slate-50 to-blue-50 rounded-lg p-3 sm:p-4 border border-slate-200">
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+          <div className="flex-1">
+            <h3 className="text-xs sm:text-sm font-bold text-gray-800 mb-1">Valuation Summary</h3>
+            <p className="text-[10px] sm:text-xs text-gray-600">
+              Comparing <span className="font-semibold text-gray-900">{symbol}</span> against
+              <span className="font-semibold text-blue-700"> SET Index</span> and
+              <span className="font-semibold text-purple-700"> {sectorName}</span> benchmarks
+            </p>
+          </div>
+          {score && score.total > 0 && (
+            <div className={`flex sm:block items-center justify-between sm:text-right gap-2`}>
+              <div className={`text-xl sm:text-2xl font-bold ${score.better > score.worse ? 'text-green-600' : score.worse > score.better ? 'text-red-600' : 'text-gray-600'}`}>
+                {score.better > score.worse ? '✓' : score.worse > score.better ? '✗' : '='}
+              </div>
+              <div className="text-[10px] sm:text-xs text-gray-500">
+                {score.better} better, {score.worse} worse
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Comparison Table */}
+      <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+        {/* Horizontal scroll container for mobile */}
+        <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
+          <div className="min-w-[500px] sm:min-w-0">
+            {/* Header */}
+            <div className="grid grid-cols-4 gap-2 sm:gap-3 px-2 sm:px-4 py-3 bg-slate-50 border-b border-gray-200">
+              <div className="text-[10px] sm:text-xs font-semibold text-gray-600 uppercase tracking-wide">Metric</div>
+              <div className="text-right text-[10px] sm:text-xs font-semibold text-gray-600 uppercase tracking-wide">Stock</div>
+              <div className="text-center text-[10px] sm:text-xs font-semibold text-blue-700 uppercase tracking-wide">SET Index</div>
+              <div className="text-right text-[10px] sm:text-xs font-semibold text-purple-700 uppercase tracking-wide">Sector</div>
+            </div>
+
+            {/* Rows */}
+            <div className="divide-y divide-gray-100">
+          {/* P/E Ratio */}
+          <ComparisonRow
+            label="P/E Ratio"
+            stockValue={metrics?.peRatio ?? null}
+            setValue={SET_INDEX_BENCHMARK.peRatio}
+            sectorValue={sectorBenchmark.peRatio!}
+            format={(v) => v.toFixed(1) + 'x'}
+            lowerBetter={true}
+          />
+
+          {/* P/BV Ratio */}
+          <ComparisonRow
+            label="P/BV Ratio"
+            stockValue={metrics?.pbRatio ?? null}
+            setValue={SET_INDEX_BENCHMARK.pbRatio}
+            sectorValue={sectorBenchmark.pbRatio!}
+            format={(v) => v.toFixed(2) + 'x'}
+            lowerBetter={true}
+          />
+
+          {/* Dividend Yield */}
+          <ComparisonRow
+            label="Dividend Yield"
+            stockValue={metrics?.dividendYield != null && metrics.dividendYield > 0 ? metrics.dividendYield * 100 : null}
+            setValue={SET_INDEX_BENCHMARK.dividendYield}
+            sectorValue={sectorBenchmark.dividendYield ?? SET_INDEX_BENCHMARK.dividendYield}
+            format={(v) => v.toFixed(1) + '%'}
+            lowerBetter={false}
+          />
+
+          {/* ROE */}
+          <ComparisonRow
+            label="ROE"
+            stockValue={metrics?.roe ?? null}
+            setValue={sectorBenchmark.roe || 15}
+            sectorValue={sectorBenchmark.roe || 15}
+            format={(v) => v.toFixed(1) + '%'}
+            lowerBetter={false}
+          />
+        </div>
+      </div>
+      </div>
+      </div>
+
+      {/* Quick Analysis Cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {/* Valuation */}
+        <div className="bg-white rounded-lg border border-gray-200 p-3">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-base sm:text-lg">💰</span>
+            <h4 className="text-xs font-semibold text-gray-700">Valuation</h4>
+          </div>
+          {metrics?.peRatio ? (
+            <>
+              <StatusBadge value={metrics.peRatio} benchmark={SET_INDEX_BENCHMARK.peRatio} lowerBetter={true} />
+              <p className="text-[10px] sm:text-xs text-gray-500 mt-2">
+                {metrics.peRatio < SET_INDEX_BENCHMARK.peRatio
+                  ? 'Stock trades below SET average - may be undervalued'
+                  : metrics.peRatio > SET_INDEX_BENCHMARK.peRatio * 1.2
+                    ? 'Stock trades at premium to SET average'
+                    : 'Stock valuation in line with market'}
+              </p>
+            </>
+          ) : (
+            <p className="text-[10px] sm:text-xs text-gray-400">No data available</p>
+          )}
+        </div>
+
+        {/* Yield */}
+        <div className="bg-white rounded-lg border border-gray-200 p-3">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-base sm:text-lg">📊</span>
+            <h4 className="text-xs font-semibold text-gray-700">Yield</h4>
+          </div>
+          {metrics?.dividendYield && metrics.dividendYield > 0 ? (
+            <>
+              <StatusBadge value={metrics.dividendYield * 100} benchmark={SET_INDEX_BENCHMARK.dividendYield} lowerBetter={false} />
+              <p className="text-[10px] sm:text-xs text-gray-500 mt-2">
+                {metrics.dividendYield * 100 > SET_INDEX_BENCHMARK.dividendYield
+                  ? 'Above average dividend yield'
+                  : 'Below average dividend yield'}
+              </p>
+            </>
+          ) : (
+            <p className="text-[10px] sm:text-xs text-gray-400">No data available</p>
+          )}
+        </div>
+
+        {/* Sector Position */}
+        <div className="bg-white rounded-lg border border-gray-200 p-3">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-base sm:text-lg">🏢</span>
+            <h4 className="text-xs font-semibold text-gray-700">Sector Position</h4>
+          </div>
+          <div className="text-sm">
+            <div className="font-semibold text-purple-700">{sectorName}</div>
+            <p className="text-[10px] sm:text-xs text-gray-500 mt-1">
+              Sector P/E: {(sectorBenchmark.peRatio ?? SET_INDEX_BENCHMARK.peRatio).toFixed(1)}x vs SET {SET_INDEX_BENCHMARK.peRatio.toFixed(1)}x
+            </p>
+            {(sectorBenchmark.peRatio ?? SET_INDEX_BENCHMARK.peRatio) < SET_INDEX_BENCHMARK.peRatio ? (
+              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs bg-green-100 text-green-700 mt-1">
+                Value sector
+              </span>
+            ) : (
+              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs bg-red-100 text-red-700 mt-1">
+                Growth sector
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center justify-center gap-3 sm:gap-6 text-[10px] sm:text-xs text-gray-500 py-2 flex-wrap">
+        <span className="flex items-center gap-1 sm:gap-1.5">
+          <span className="w-2.5 h-2.5 sm:w-3 sm:h-3 bg-green-100 rounded-full"></span>
+          <span>Green = Better than standard</span>
+        </span>
+        <span className="flex items-center gap-1 sm:gap-1.5">
+          <span className="w-2.5 h-2.5 sm:w-3 sm:h-3 bg-red-100 rounded-full"></span>
+          <span>Red = Below standard</span>
+        </span>
+        <span className="flex items-center gap-1 sm:gap-1.5">
+          <span className="w-2.5 h-2.5 sm:w-3 sm:h-3 bg-gray-100 rounded-full"></span>
+          <span>Gray = In line (±5%)</span>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/sectorStandards.ts
+++ b/src/lib/sectorStandards.ts
@@ -1,0 +1,264 @@
+/**
+ * Thai Market Sector Standards and Benchmarks
+ * Center standard information for SET stocks comparison
+ * Data updated: 2024-2025
+ * Sources:
+ * - SET Annual Report 2024
+ * - Bloomberg SET Index Data
+ * - MSCI Thailand Index Factsheet
+ * - CEIC Data
+ * - Fitch Ratings, Kasikornbank Research, Thanachart Securities
+ */
+
+// SET Index Overall Benchmark Standards (Updated 2024-2025)
+// Latest SET metrics: P/E 15.4x, P/BV 1.22x, Dividend Yield 3.71%
+export const SET_INDEX_BENCHMARK = {
+  name: 'SET Index',
+  peRatio: 15.4,
+  pbRatio: 1.22,
+  dividendYield: 3.7,
+} as const;
+
+// Sector Peer Groups with representative stocks and updated benchmarks
+// Research sources: SimplyWall.st, Fitch Ratings, Kasikornbank Research,
+// Thanachart Securities, SET Official Data
+export const SECTOR_PEER_GROUPS: Record<string, {
+  name: string;
+  peers: string[];
+  benchmark?: {
+    peRatio?: number;
+    pbRatio?: number;
+    dividendYield?: number;
+    roe?: number;
+  };
+}> = {
+  // Banking & Finance (Industry P/E: 7.9x, 3-year avg)
+  // Source: Fitch Ratings, Kasikornbank Research 2024
+  BANKING: {
+    name: 'Banking',
+    peers: ['BBL', 'KBANK', 'SCB', 'KTB', 'CIMBT', 'TMB', 'TISCO', 'KKP', 'BAY'],
+    benchmark: {
+      peRatio: 7.9,
+      pbRatio: 0.8,
+      dividendYield: 5.5,
+      roe: 11.5,
+    },
+  },
+
+  // Energy (Industry P/E: 11.7x, 3-year avg 9.2x)
+  // PTT P/E: 12.7x, PTTEP: ~8-10x
+  // Source: Thanachart Securities Energy Sector 2025
+  ENERGY: {
+    name: 'Energy',
+    peers: ['PTT', 'PTTEP', 'TOP', 'BCH', 'BDMS', 'GULF', 'OR', 'IRPC', 'PTTGC'],
+    benchmark: {
+      peRatio: 11.7,
+      pbRatio: 1.1,
+      dividendYield: 5.0,
+      roe: 14.5,
+    },
+  },
+
+  // Telecommunications (Peer avg P/E: 14.4x)
+  // INTUCH: 17.02x-23.1x, TRUE: expensive (turnaround), ADVANC: premium
+  // 3-year avg was 84.4x, now compressed significantly
+  // Source: Thanachart Telecom Sector 2025
+  TELECOMMUNICATION: {
+    name: 'Telecommunication',
+    peers: ['ADVANC', 'INTUCH', 'TRUE', 'DTAC', 'THCOM'],
+    benchmark: {
+      peRatio: 14.4,
+      pbRatio: 2.5,
+      dividendYield: 4.0,
+      roe: 16.0,
+    },
+  },
+
+  // Property & Real Estate (Industry P/E: 13.5x)
+  // AP: 6.4x-6.5x (undervalued vs fair P/E 7.6x), LH: 9.1x, FPT: 18.4x
+  // Source: SET Property Data, JLL Research 2024
+  PROPERTY: {
+    name: 'Property',
+    peers: ['AP', 'LH', 'QH', 'SF', 'MEGA', 'PSL', 'MTL', 'FPT', 'ORI', 'PRIN'],
+    benchmark: {
+      peRatio: 13.5,
+      pbRatio: 0.7,
+      dividendYield: 4.0,
+      roe: 9.0,
+    },
+  },
+
+  // Automotive
+  // Source: F&S Thailand Automotive 2024
+  AUTOMOTIVE: {
+    name: 'Automotive',
+    peers: ['TA', 'HMPRO', 'GPSC', 'SOKE', 'STEC', 'ADVICE'],
+    benchmark: {
+      peRatio: 12.5,
+      pbRatio: 1.2,
+      dividendYield: 3.5,
+      roe: 11.0,
+    },
+  },
+
+  // Food & Beverage (Agro & Food Industry)
+  // Source: SET Agro & Food Index Data
+  FOOD: {
+    name: 'Food & Beverage',
+    peers: ['CPF', 'MFC', 'TFM', 'TUF', 'TKS', 'SFP', 'TCP', 'AOT'],
+    benchmark: {
+      peRatio: 15.0,
+      pbRatio: 1.5,
+      dividendYield: 3.2,
+      roe: 12.5,
+    },
+  },
+
+  // Retail & Wholesale
+  // CPALL, HMPRO are major players
+  // Source: Thanachart Retail Sector 2024
+  RETAIL: {
+    name: 'Retail',
+    peers: ['CPALL', 'BJC', 'OTCP', 'HMPRO', 'BTS', 'ERW', 'MAKRO', 'POWER_D'],
+    benchmark: {
+      peRatio: 20.0,
+      pbRatio: 4.0,
+      dividendYield: 3.0,
+      roe: 15.0,
+    },
+  },
+
+  // Health Care
+  // BDMS is major player with premium valuation
+  // Source: SET Healthcare Index
+  HEALTHCARE: {
+    name: 'Health Care',
+    peers: ['BDMS', 'BH', 'PRG', 'CHG', 'SIH', 'ACC', 'NHealth'],
+    benchmark: {
+      peRatio: 28.0,
+      pbRatio: 3.5,
+      dividendYield: 2.0,
+      roe: 15.0,
+    },
+  },
+
+  // Technology (ICT)
+  // JAS, FORTH are key players
+  // Source: SET ICT Index
+  TECHNOLOGY: {
+    name: 'Technology',
+    peers: ['JAS', 'FORTH', 'SIS', 'SAUCE', 'SYNEX', 'IVL'],
+    benchmark: {
+      peRatio: 25.0,
+      pbRatio: 3.0,
+      dividendYield: 1.5,
+      roe: 14.0,
+    },
+  },
+
+  // Building Materials & Construction
+  // Source: SET Construction Index
+  BUILDING_MATERIALS: {
+    name: 'Building Materials',
+    peers: ['SSC', 'TPIPL', 'SUC', 'DRT', 'VGI', 'SGP', 'CIMBT'],
+    benchmark: {
+      peRatio: 10.5,
+      pbRatio: 1.0,
+      dividendYield: 4.0,
+      roe: 10.0,
+    },
+  },
+
+  // Transportation & Logistics
+  // BTS, AOT are key players in transportation
+  // RATCH is a utility play
+  // Source: SET Services Index
+  TRANSPORTATION: {
+    name: 'Transportation',
+    peers: ['BTS', 'AOT', 'RATCH', 'GI', 'WHA', 'KSS', 'NCL'],
+    benchmark: {
+      peRatio: 16.0,
+      pbRatio: 1.3,
+      dividendYield: 3.5,
+      roe: 12.0,
+    },
+  },
+
+  // Insurance
+  // Source: SET Insurance Index
+  INSURANCE: {
+    name: 'Insurance',
+    peers: ['THAI', 'VNT', 'SMK', 'FSSTB', 'MTI'],
+    benchmark: {
+      peRatio: 9.0,
+      pbRatio: 1.0,
+      dividendYield: 4.5,
+      roe: 11.0,
+    },
+  },
+
+  // Petrochemicals
+  // PTTGC is major player
+  // Source: PTT Research, Industry Reports
+  PETROCHEMICALS: {
+    name: 'Petrochemicals',
+    peers: ['PTTGC', 'IRPC', 'GPC', 'TPIPL', 'RPC'],
+    benchmark: {
+      peRatio: 12.0,
+      pbRatio: 1.2,
+      dividendYield: 4.2,
+      roe: 13.0,
+    },
+  },
+
+  // Electricity & Utilities
+  // GULF, BGRIM, RATCH are major IPPs
+  // Source: SET Utilities Index
+  UTILITIES: {
+    name: 'Utilities',
+    peers: ['GULF', 'BGRIM', 'RATCH', 'BPP', 'QH', 'EA'],
+    benchmark: {
+      peRatio: 16.5,
+      pbRatio: 1.5,
+      dividendYield: 3.8,
+      roe: 13.5,
+    },
+  },
+};
+
+// Helper function to get sector group for a stock symbol
+export function getSectorForSymbol(symbol: string): keyof typeof SECTOR_PEER_GROUPS | null {
+  const upperSymbol = symbol.toUpperCase().replace('.BK', '');
+
+  for (const [key, group] of Object.entries(SECTOR_PEER_GROUPS)) {
+    if (group.peers.includes(upperSymbol)) {
+      return key as keyof typeof SECTOR_PEER_GROUPS;
+    }
+  }
+
+  return null;
+}
+
+// Helper function to get sector benchmark
+export function getSectorBenchmark(symbol: string) {
+  const sector = getSectorForSymbol(symbol);
+  if (!sector) return null;
+  return SECTOR_PEER_GROUPS[sector].benchmark || null;
+}
+
+// Helper function to get peer stocks for a symbol
+export function getPeerStocks(symbol: string): string[] {
+  const sector = getSectorForSymbol(symbol);
+  if (!sector) return [];
+  return SECTOR_PEER_GROUPS[sector].peers.filter(p => p !== symbol.toUpperCase().replace('.BK', ''));
+}
+
+// Helper function to get sector name
+export function getSectorName(symbol: string): string | null {
+  const sector = getSectorForSymbol(symbol);
+  if (!sector) return null;
+  return SECTOR_PEER_GROUPS[sector].name;
+}
+
+// All available sectors
+export const ALL_SECTORS = Object.keys(SECTOR_PEER_GROUPS) as Array<keyof typeof SECTOR_PEER_GROUPS>;


### PR DESCRIPTION
## Summary

Add comprehensive sector benchmark and peer comparison tools for Thai SET stocks with professional investor-friendly design.

## Changes

- **sectorStandards.ts**: Add 14 Thai SET sectors with 2024-2025 benchmarks
  - SET Index benchmarks: P/E 15.4x, P/B 1.22x, Div Yield 3.7%
  - 14 sectors: Banking, Energy, Telecom, Property, Automotive, Food, Retail, Healthcare, Technology, Building Materials, Transportation, Insurance, Petrochemicals, Utilities

- **StandardBenchmarks** (new): Stock vs SET Index vs Sector comparison
  - Professional comparison table with color-coded indicators
  - Quick Analysis Cards (Valuation, Yield, Sector Position)
  - Mobile-responsive design

- **PeerComparison** (redesign): Enhanced peer comparison
  - Overall Performance Summary with arrows
  - Rank badges (green #1-3, yellow above avg, red below avg)
  - Performance indicators (up/down for better/worse than avg)
  - Custom stock input/removal functionality
  - Mobile-friendly table with sticky columns

- **PriceChart**: Add MA150 (orange line) alongside MA50 (yellow) and MA200 (red)

- **Stock Detail Page**: Add 52-week high/low display with % distance, volume ratio indicator

## Test plan

- [x] Build succeeds
- [x] Standard Benchmarks displays correctly for Thai SET stocks
- [x] Peer Comparison allows adding/removing custom stocks
- [x] Price Chart shows all 3 MA lines when sufficient data available
- [x] Mobile responsive design works correctly